### PR TITLE
Mobile view

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -10,18 +10,18 @@
 {#if isRevealed}
   <div class="inline-block">
     <div
-      class="flex flex-col items-center justify-center w-36 h-56 p-2 m-2 font-bold bg-teal-50 rounded-lg border-4 border-teal-600 text-teal-700"
+      class="flex flex-col items-center justify-center w-18 h-28 md:w-36 md:h-56 p-2 m-2 font-bold bg-teal-50 rounded-lg border-4 border-teal-600 text-teal-700"
     >
-      <div class="text-6xl">{displayValue}</div>
+      <div class="text-3xl md:text-6xl">{displayValue}</div>
       <div>{username}</div>
     </div>
   </div>
 {:else}
   <div class="inline-block">
     <div
-      class="flex flex-col items-center justify-center w-36 h-56 p-2 m-2 font-bold bg-teal-700 rounded-lg border-5 border-teal-900 text-teal-50"
+      class="flex flex-col items-center justify-center w-18 h-28 md:w-36 md:h-56 p-2 m-2 font-bold bg-teal-700 rounded-lg border-5 border-teal-900 text-teal-50"
     >
-      <div class="text-6xl text-lime-400">
+      <div class="text-3xl md:text-6xl text-lime-400">
         {#if hasValue}
           !
         {:else}

--- a/frontend/src/lib/components/base/TgHeadingMain.svelte
+++ b/frontend/src/lib/components/base/TgHeadingMain.svelte
@@ -3,6 +3,8 @@
   export { additionalClasses as class };
 </script>
 
-<h2 class={`font-bold font-sans mb-2 text-4xl ${additionalClasses}`}>
+<h2
+  class={`font-bold font-sans mb-2 text-2xl md:text-4xl ${additionalClasses}`}
+>
   <slot />
 </h2>

--- a/frontend/src/lib/components/base/TgHeadingTitle.svelte
+++ b/frontend/src/lib/components/base/TgHeadingTitle.svelte
@@ -3,6 +3,8 @@
   export { additionalClasses as class };
 </script>
 
-<h1 class={`font-bold font-sans mb-8 uppercase text-6xl ${additionalClasses}`}>
+<h1
+  class={`font-bold font-sans mb-8 uppercase text-3xl md:text-6xl ${additionalClasses}`}
+>
   <slot />
 </h1>

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -96,7 +96,7 @@
   <TgParagraph>Loading room...</TgParagraph>
 {:else}
   <header class="mt-8">
-    Room URL: {url}
+    Room URL: <span class="whitespace-nowrap">{url}</span>
     {#if hostKey}
       <TgButton
         id="deleteRoomButton"


### PR DESCRIPTION
## Context

On mobile, the title gets cut off on the home page and cards are too big. This sets better styles for mobile and uses breakpoints to revert to bigger styles.

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [ ] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

