### PR TITLE
Remove api domain

### DIFF
--- a/docs/how-to/deploy-manually.md
+++ b/docs/how-to/deploy-manually.md
@@ -12,7 +12,7 @@ However, you might want to do this if you want to deploy your own copy of the ap
 
 ## Prerequisites
 
-- Update the `apexDomain` in `infra/index.ts` to specify a domain that you already own and have set up in Route53.
+- Update the `apexDomain` in `infra/lib/DomainName.ts` to specify a domain that you already own and have set up in Route53.
   - Ideally the domain should be more externalized. This is a good opportunity to improve the codebase. Consider [creating a task](https://github.com/skill-collectors/guesstimator/issues/new?assignees=&labels=&template=new-task.md&title=Externalize%20domain) on the project board and giving it a try.
 - Ensure that your AWS CLI account has the correct deploy permissions. The following policies are sufficient, but could be a lot narrower if you wanted to figure that out:
   - `AWSCertificateManagerFullAccess`

--- a/docs/how-to/deploy-manually.md
+++ b/docs/how-to/deploy-manually.md
@@ -19,6 +19,7 @@ However, you might want to do this if you want to deploy your own copy of the ap
   - `AWSLambda_FullAccess `
   - `AmazonAPIGatewayAdministrator`
   - `AmazonDynamoDBFullAccess`
+  - `AmazonEventBridgeFullAccess`
   - `AmazonRoute53FullAccess`
   - `AmazonS3FullAccess`
   - `CloudFrontFullAccess`

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -4,7 +4,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import Api from "./lib/Api";
 import { registerAutoTags } from "./lib/AutoTag";
-import { subDomain, apiSubDomain, apexDomain } from "./lib/DomainName";
+import { subDomain, apexDomain } from "./lib/DomainName";
 import { capitalize } from "./lib/utils/StringUtils";
 import { buildCallbackFunction } from "./lib/Lambda";
 import { createStaleRoomCleanupFunction } from "./lib/lambda/CleanupMain";
@@ -29,8 +29,6 @@ const svelteApp = isLocalDev
 const database = new Database(`${resourceNamePrefix}-Database`);
 
 const api = new Api(`${resourceNamePrefix}-Api`, {
-  subDomain: apiSubDomain,
-  apexDomain: isLocalDev ? null : apexDomain,
   database,
 });
 

--- a/infra/lib/Api.ts
+++ b/infra/lib/Api.ts
@@ -6,8 +6,8 @@ import Database from "./Database";
 import { buildCallbackFunction } from "./Lambda";
 
 export interface ApiArgs {
-  subDomain: string;
-  apexDomain: string | null;
+  subDomain?: string;
+  apexDomain?: string;
   database: Database;
 }
 
@@ -76,7 +76,7 @@ export default class Api extends pulumi.ComponentResource {
     const apiKey = addApiUsagePlan();
     this.apiKey = apiKey.value;
 
-    if (args.apexDomain === null) {
+    if (args.apexDomain === undefined || args.subDomain === undefined) {
       this.url = api.url;
     } else {
       this.url = addDomainName(args.subDomain, args.apexDomain);

--- a/infra/lib/DomainName.ts
+++ b/infra/lib/DomainName.ts
@@ -5,7 +5,4 @@ const stack = pulumi.getStack();
 export const subDomain =
   stack === "prod" ? "guesstimator" : `guesstimator-${stack}`;
 
-export const apiSubDomain =
-  stack === "prod" ? "guesstimator-api" : `guesstimator-api-${stack}`;
-
 export const apexDomain = "superfun.link";

--- a/infra/tests/lib/Api.test.ts
+++ b/infra/tests/lib/Api.test.ts
@@ -42,10 +42,7 @@ describe("infrastructure", () => {
     });
   });
 
-  function buildApi(
-    apexDomain: string | null = "example.com",
-    subDomain = "www"
-  ) {
+  function buildApi() {
     return new Api("GuesstimatorApi", {
       database: {
         table: {
@@ -53,20 +50,11 @@ describe("infrastructure", () => {
           name: pulumi.Output.create("tableName"),
         },
       } as unknown as Database,
-      apexDomain,
-      subDomain,
     });
   }
 
-  it("Creates an API url", async () => {
+  it("Exports an API url", async () => {
     const api = buildApi();
-    const apiUrl = await new Promise((resolve) => {
-      api.url.apply((url) => resolve(url));
-    });
-    expect(apiUrl).toBe("https://www.example.com");
-  });
-  it("Skips base path mapping if apexDomain is null", async () => {
-    const api = buildApi(null);
     const apiUrl = await new Promise((resolve) => {
       api.url.apply((url) => resolve(url));
     });


### PR DESCRIPTION
## Context

Certain corporate networks (who will remain nameless) use filtering software that is too stupid to unblock a backend API that is required for a site when unblocking the root domain.

We could re-use the same domain for both front and back end, but then we'd have to disambiguate them with a path and this is just easier.

The only information "exposed" by the raw domain (which users never see) is that we are deploying to AWS in a specific region, but that information is in the (publicly available) source code anyway.

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

