### PR TITLE
Case insensitive headers

### DIFF
--- a/infra/lib/lambda/rest/CaseInsensitiveHeadersPlugin.ts
+++ b/infra/lib/lambda/rest/CaseInsensitiveHeadersPlugin.ts
@@ -1,0 +1,28 @@
+/**
+ * This plugin ensures that all headers are fully lowercase.
+ *
+ * The spec says that all headers are case-insensitive: https://www.rfc-editor.org/rfc/rfc7230#section-3.2
+ *
+ * In practice, we sometimes get "Origin" and other times "origin". Since the AWS SDK provides 'headers' as an object,
+ * and object property lookups are case-sensitive, we need to take this extra step to ensure they are all fully lowercase.
+ *
+ * By running this plugin first, subsequent plugins don't have to worry about it when they look up headers.
+ */
+import { APIGatewayProxyEvent, APIGatewayProxyEventHeaders } from "aws-lambda";
+import { LambdaHandler } from "./Router";
+
+export function caseInsensitiveHeaders() {
+  return {
+    applyTo(handler: LambdaHandler): LambdaHandler {
+      return async (event: APIGatewayProxyEvent) => {
+        const lowerCaseHeaders: APIGatewayProxyEventHeaders = {};
+        for (const header in event.headers) {
+          lowerCaseHeaders[header.toLocaleLowerCase()] = event.headers[header];
+        }
+        event.headers = lowerCaseHeaders;
+        const response = await handler(event);
+        return response;
+      };
+    },
+  };
+}

--- a/infra/lib/lambda/rest/Main.ts
+++ b/infra/lib/lambda/rest/Main.ts
@@ -1,8 +1,9 @@
 import * as pulumi from "@pulumi/pulumi";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { corsRules } from "./CorsPlugin";
-import { initRouter } from "./Router";
+import { initRouter, LambdaHandler } from "./Router";
 import { serverError } from "./Response";
+import { caseInsensitiveHeaders } from "./CaseInsensitiveHeadersPlugin";
 
 /**
  * Creates the main Lambda Function for this REST API.
@@ -28,16 +29,24 @@ export function createMainRestFunction(tableName: pulumi.Output<string>) {
 
       const router = initRouter(tableName.get());
 
-      const main = corsPlugin.applyTo(async (event) => {
-        try {
-          return await router.run(event);
-        } catch (err) {
-          // Catch here to apply CORS if we can
-          return await new Promise((resolve) =>
-            resolve(serverError(err, event))
-          );
+      const plugins = [caseInsensitiveHeaders(), corsPlugin];
+
+      // reduceRight will ensure that plugins run in the order they are defined in the array
+      // so caseInsensitiveHeaders runs before corsPlugin
+      const main = plugins.reduceRight(
+        (handler: LambdaHandler, plugin) => plugin.applyTo(handler),
+        async (event) => {
+          try {
+            return await router.run(event);
+          } catch (err) {
+            // Catch here to apply CORS if we can
+            return await new Promise((resolve) =>
+              resolve(serverError(err, event))
+            );
+          }
         }
-      });
+      );
+
       return await main(event);
     } catch (err) {
       // No CORS applied in this case

--- a/infra/tests/lib/lambda/rest/CaseInsensitiveHeadersPlugin.test.ts
+++ b/infra/tests/lib/lambda/rest/CaseInsensitiveHeadersPlugin.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { caseInsensitiveHeaders } from "../../../../lib/lambda/rest/CaseInsensitiveHeadersPlugin";
+import { stubEvent } from "../Stubs";
+
+describe("CorsPlugin", () => {
+  const stubHandler = vi.fn();
+  const plugin = caseInsensitiveHeaders();
+  const handler = plugin.applyTo(stubHandler);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Forces all headers to lowercase", async () => {
+    // Given
+    const event = stubEvent("OPTIONS", "/", "", {
+      Origin: "http://localhost",
+    });
+
+    // When
+    await handler(event);
+    const transformedEvent = stubHandler.mock.calls[0][0];
+
+    // Then
+    expect(transformedEvent.headers.origin).toBeTruthy();
+  });
+});

--- a/local-logs-list.sh
+++ b/local-logs-list.sh
@@ -5,7 +5,7 @@ set -e
 logGroups="$(awslocal logs describe-log-groups --query 'logGroups[*].logGroupName' | jq -r '.[]')"
 
 while IFS= read -r logGroup; do
-  logStreams="$(awslocal logs describe-log-streams --log-group-name ${logGroup} --query 'logStreams[*].logStreamName' --limit 50 | jq -r '.[]')"
+  logStreams="$(awslocal logs describe-log-streams --log-group-name ${logGroup} --query 'logStreams[*].logStreamName' --descending --limit 50 | jq -r '.[]')"
   while IFS= read -r logStream; do
     awslocal logs get-log-events --log-group-name "${logGroup}" --log-stream-name "${logStream}"
   done <<< "${logStreams}"


### PR DESCRIPTION
## Context

Sometimes CORS fails because we get an 'Origin' header instead of an 'origin' header. This PR ensures they are always lowercase.

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

