### PR TITLE
Improve user status tracking

### DIFF
--- a/frontend/src/lib/services/rooms.ts
+++ b/frontend/src/lib/services/rooms.ts
@@ -7,6 +7,16 @@ export interface Room {
   isRevealed: boolean;
   users: User[];
 }
+export function isRoom(value: unknown): value is Room {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "roomId" in value &&
+    "validSizes" in value &&
+    "isRevealed" in value &&
+    "users" in value
+  );
+}
 
 export interface User {
   userKey?: string;

--- a/frontend/src/lib/services/websockets.ts
+++ b/frontend/src/lib/services/websockets.ts
@@ -52,6 +52,7 @@ export class GuesstimatorWebSocket {
     if (this.userKey === undefined) {
       throw new Error("Cannot join without a userKey");
     }
+    console.log(`Joining room as ${username}`);
     this.webSocket.send(
       JSON.stringify({
         action: "join",
@@ -67,6 +68,7 @@ export class GuesstimatorWebSocket {
     if (this.userKey === undefined) {
       throw new Error("Cannot vote without a userKey");
     }
+    console.log(`Sending vote: ${vote}`);
     this.webSocket.send(
       JSON.stringify({
         action: "vote",
@@ -82,6 +84,7 @@ export class GuesstimatorWebSocket {
     if (this.userKey === undefined) {
       throw new Error("Cannot leave without a userKey");
     }
+    console.log("Leaving room");
     this.webSocket.send(
       JSON.stringify({
         action: "leave",

--- a/frontend/src/lib/services/websockets.ts
+++ b/frontend/src/lib/services/websockets.ts
@@ -62,6 +62,18 @@ export class GuesstimatorWebSocket {
   }
 
   /**
+   * Sends a "ping" to keep the web socket open
+   */
+  ping() {
+    console.log(">> PING!");
+    this.webSocket.send(
+      JSON.stringify({
+        action: "ping",
+        data: {},
+      }),
+    );
+  }
+  /**
    * Submits a vote for the user. The user must be joined.
    */
   vote(vote: string) {

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -225,23 +225,26 @@
     <section id="resultsChart" class="m-x-auto max-w-xl">
       <ResultsChart {roomData} />
     </section>
-  {:else}
-    <section id="userControls" class="mt-32">
-      {#if currentUser !== undefined && currentUser.username.length > 0}
-        <TgHeadingSub>Your vote:</TgHeadingSub>
-        <VoteControls {roomData} {currentUser} on:vote={handleVote} />
-        <TgParagraph>
-          You are joined as <strong>{currentUser.username}</strong>
-          <TgButton type="danger" class="m-2" on:click={handleLeave}
-            >Leave</TgButton
-          >
-        </TgParagraph>
-      {:else}
-        <TgParagraph
-          >If you'd like to vote, enter a name and join the room:</TgParagraph
-        >
-        <NewUserForm on:submit={handleNewUser} />
-      {/if}
-    </section>
   {/if}
+  <section id="userControls" class="mt-32">
+    {#if currentUser === undefined || currentUser.username.length === 0}
+      <TgParagraph
+        >If you'd like to vote, enter a name and join the room:</TgParagraph
+      >
+      <NewUserForm on:submit={handleNewUser} />
+    {:else}
+      {#if roomData?.isRevealed === true}
+        <TgHeadingSub>Your vote: {currentUser.vote}</TgHeadingSub>
+      {:else}
+        <TgHeadingSub>Your vote: {currentUser.vote}</TgHeadingSub>
+        <VoteControls {roomData} {currentUser} on:vote={handleVote} />
+      {/if}
+      <TgParagraph>
+        You are joined as <strong>{currentUser.username}</strong>
+        <TgButton type="danger" class="m-2" on:click={handleLeave}
+          >Leave</TgButton
+        >
+      </TgParagraph>
+    {/if}
+  </section>
 {/if}

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -97,8 +97,10 @@
         webSocket.close();
         localStorage.clearUserData(roomId);
         window.location.reload();
-      } else {
+      } else if (rooms.isRoom(message.data)) {
         roomData = message.data;
+      } else {
+        console.log(`Could not handle message: ${JSON.stringify(message)}`);
       }
     }
   }

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -31,11 +31,23 @@
 
   $: if (currentUser?.userKey !== undefined && webSocket !== undefined) {
     webSocket.userKey = currentUser.userKey;
-    localStorage.storeUserData(
-      roomId,
-      currentUser.userKey,
-      currentUser.username
-    );
+
+    const existingUserData = localStorage.getUserData(roomId);
+    if (
+      existingUserData !== undefined &&
+      existingUserData.username !== undefined &&
+      existingUserData.username !== "" &&
+      currentUser?.username === ""
+    ) {
+      console.log("Current user got kicked. Rejoining...");
+      webSocket?.join(existingUserData.username);
+    } else {
+      localStorage.storeUserData(
+        roomId,
+        currentUser.userKey,
+        currentUser.username
+      );
+    }
   }
 
   onMount(() => {

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -27,7 +27,7 @@
 
   let loadingStatus = "";
 
-  let isJoining = false;
+  let isJoiningOrLeaving = false;
 
   $: currentUser = roomData?.users.find((user) => user.userKey !== undefined);
 
@@ -43,7 +43,7 @@
     ) {
       console.log("Current user got kicked. Rejoining...");
       webSocket?.join(existingUserData.username);
-      isJoining = true;
+      isJoiningOrLeaving = true;
     } else {
       localStorage.storeUserData(
         roomId,
@@ -109,7 +109,7 @@
         console.log("<< PONG");
       } else if (rooms.isRoom(message.data)) {
         roomData = message.data;
-        isJoining = false;
+        isJoiningOrLeaving = false;
       } else {
         console.log(`Could not handle message: ${JSON.stringify(message)}`);
       }
@@ -129,7 +129,7 @@
 
   function handleNewUser(e: CustomEvent<{ username: string }>) {
     webSocket?.join(e.detail.username);
-    isJoining = true;
+    isJoiningOrLeaving = true;
   }
 
   function handleVote(e: CustomEvent<{ vote: string }>) {
@@ -144,6 +144,7 @@
       currentUser.username = "";
       localStorage.storeUserData(roomId, currentUser.userKey);
       webSocket?.leave();
+      isJoiningOrLeaving = true;
     }
   }
 
@@ -228,7 +229,7 @@
   {/if}
   <section id="userControls" class="mt-32">
     {#if currentUser === undefined || currentUser.username.length === 0}
-      {#if isJoining === true}
+      {#if isJoiningOrLeaving === true}
         <Loader />
       {:else}
         <TgParagraph

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -85,8 +85,6 @@
   }
 
   function onWebSocketMessage(this: WebSocket, event: MessageEvent) {
-    console.log(event);
-
     loadingStatus = "";
 
     if (webSocket === undefined) {
@@ -96,7 +94,9 @@
     }
     const json = event.data;
     if (json !== undefined) {
+      console.log(`Recieved message: ${json}`);
       const message = JSON.parse(json);
+
       if (message.status !== 200) {
         console.error(message);
         if (message.status === 404) {

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -107,13 +107,6 @@
         }
       } else if (message.data.type === "PONG") {
         console.log("<< PONG");
-      } else if (
-        message.data.type === "DELETE_USER" &&
-        message.data.result === "SUCCESS"
-      ) {
-        webSocket.close();
-        localStorage.clearUserData(roomId);
-        window.location.reload();
       } else if (rooms.isRoom(message.data)) {
         roomData = message.data;
         isJoining = false;
@@ -148,6 +141,8 @@
 
   function handleLeave() {
     if (currentUser !== undefined) {
+      currentUser.username = "";
+      localStorage.storeUserData(roomId, currentUser.userKey);
       webSocket?.leave();
     }
   }

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -27,6 +27,8 @@
 
   let loadingStatus = "";
 
+  let isJoining = false;
+
   $: currentUser = roomData?.users.find((user) => user.userKey !== undefined);
 
   $: if (currentUser?.userKey !== undefined && webSocket !== undefined) {
@@ -41,6 +43,7 @@
     ) {
       console.log("Current user got kicked. Rejoining...");
       webSocket?.join(existingUserData.username);
+      isJoining = true;
     } else {
       localStorage.storeUserData(
         roomId,
@@ -113,6 +116,7 @@
         window.location.reload();
       } else if (rooms.isRoom(message.data)) {
         roomData = message.data;
+        isJoining = false;
       } else {
         console.log(`Could not handle message: ${JSON.stringify(message)}`);
       }
@@ -132,6 +136,7 @@
 
   function handleNewUser(e: CustomEvent<{ username: string }>) {
     webSocket?.join(e.detail.username);
+    isJoining = true;
   }
 
   function handleVote(e: CustomEvent<{ vote: string }>) {
@@ -228,10 +233,14 @@
   {/if}
   <section id="userControls" class="mt-32">
     {#if currentUser === undefined || currentUser.username.length === 0}
-      <TgParagraph
-        >If you'd like to vote, enter a name and join the room:</TgParagraph
-      >
-      <NewUserForm on:submit={handleNewUser} />
+      {#if isJoining === true}
+        <Loader />
+      {:else}
+        <TgParagraph
+          >If you'd like to vote, enter a name and join the room:</TgParagraph
+        >
+        <NewUserForm on:submit={handleNewUser} />
+      {/if}
     {:else}
       {#if roomData?.isRevealed === true}
         <TgHeadingSub>Your vote: {currentUser.vote}</TgHeadingSub>

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -102,6 +102,8 @@
         if (message.status === 404) {
           notFound = true;
         }
+      } else if (message.data.type === "PONG") {
+        console.log("<< PONG");
       } else if (
         message.data.type === "DELETE_USER" &&
         message.data.result === "SUCCESS"
@@ -164,8 +166,28 @@
     localStorage.deleteHostKey(roomData.roomId);
     window.location.href = "/";
   }
+
+  let clearReloadInterval: number;
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      if (clearReloadInterval !== undefined) {
+        window.clearInterval(clearReloadInterval);
+      }
+    } else {
+      if (roomData !== null) {
+        webSocket?.ping();
+      }
+      clearReloadInterval = window.setInterval(() => {
+        webSocket?.ping();
+      }, 300_000); // every 5 minutes
+    }
+  }
+  onMount(() => {
+    handleVisibilityChange();
+  });
 </script>
 
+<svelte:document on:visibilitychange={handleVisibilityChange} />
 <svelte:head>
   <title>Guesstimator - {roomData?.roomId ?? "New"}</title>
   <meta name="description" content={`Page for room ${roomData?.roomId}`} />

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -96,8 +96,8 @@
       return;
     }
     const json = event.data;
-    if (json !== undefined) {
-      console.log(`Recieved message: ${json}`);
+    console.log(`Recieved message: ${json}`);
+    if (json !== undefined && typeof json === "string" && json.length > 0) {
       const message = JSON.parse(json);
 
       if (message.status !== 200) {

--- a/infra/lib/lambda/DbService.ts
+++ b/infra/lib/lambda/DbService.ts
@@ -193,7 +193,7 @@ export class DbService {
     console.log(`Added user ${username} with key ${userKey} to room ${roomId}`);
     return { username };
   }
-  async kick(roomId: string, userKey: string) {
+  async kickUser(roomId: string, userKey: string) {
     const pk = `ROOM:${roomId}`;
     const sk = `USER:${userKey}`;
     const updatedOn = new Date().toISOString();

--- a/infra/lib/lambda/DbService.ts
+++ b/infra/lib/lambda/DbService.ts
@@ -193,6 +193,26 @@ export class DbService {
     console.log(`Added user ${username} with key ${userKey} to room ${roomId}`);
     return { username };
   }
+  async kick(roomId: string, userKey: string) {
+    const pk = `ROOM:${roomId}`;
+    const sk = `USER:${userKey}`;
+    const updatedOn = new Date().toISOString();
+    await this.client
+      .update({
+        TableName: this.tableName,
+        Key: { PK: pk, SK: sk },
+        ConditionExpression: "PK = :pk AND SK = :sk",
+        UpdateExpression: "SET updatedOn = :updatedOn, username = :username",
+        ExpressionAttributeValues: {
+          ":pk": pk,
+          ":sk": sk,
+          ":updatedOn": updatedOn,
+          ":username": "",
+        },
+      })
+      .promise();
+    console.log(`Kicked user with key ${userKey} in room ${roomId}`);
+  }
   async vote(roomId: string, userKey: string, vote: string) {
     const pk = `ROOM:${roomId}`;
     const sk = `USER:${userKey}`;

--- a/infra/lib/lambda/websockets/ConnectionGoneError.ts
+++ b/infra/lib/lambda/websockets/ConnectionGoneError.ts
@@ -1,0 +1,10 @@
+export class ConnectionGoneError extends Error {
+  connectionId;
+
+  constructor(connectionId: string) {
+    super(`Connection ${connectionId} is gone.`);
+    Object.setPrototypeOf(this, ConnectionGoneError.prototype);
+
+    this.connectionId = connectionId;
+  }
+}

--- a/infra/lib/lambda/websockets/Main.ts
+++ b/infra/lib/lambda/websockets/Main.ts
@@ -52,6 +52,13 @@ export function createMainWebSocketFunction(
           400,
           "Missing body.action",
         );
+      } else if (body.action === "ping") {
+        await publisher.sendMessage(event.requestContext.connectionId, {
+          status: 200,
+          data: {
+            type: "PONG",
+          },
+        });
       } else if (typeof body.data !== "object") {
         await publisher.sendError(
           event.requestContext.connectionId,

--- a/infra/lib/lambda/websockets/Main.ts
+++ b/infra/lib/lambda/websockets/Main.ts
@@ -27,9 +27,13 @@ export function createMainWebSocketFunction(
       const publishRoomDataResult = await publisher.publishRoomData(
         await db.getRoom(roomId),
       );
-      for (const userKey of publishRoomDataResult.goneUserKeys) {
-        console.log(`Removing gone user ${userKey} from room ${roomId}`);
-        await db.kickUser(roomId, userKey);
+      if (publishRoomDataResult.goneUserKeys.length > 0) {
+        for (const userKey of publishRoomDataResult.goneUserKeys) {
+          console.log(`Removing gone user ${userKey} from room ${roomId}`);
+          await db.kickUser(roomId, userKey);
+        }
+        // Republish without kicked users
+        await publisher.publishRoomData(await db.getRoom(roomId));
       }
     }
 

--- a/infra/lib/lambda/websockets/Main.ts
+++ b/infra/lib/lambda/websockets/Main.ts
@@ -29,7 +29,7 @@ export function createMainWebSocketFunction(
       );
       for (const userKey of publishRoomDataResult.goneUserKeys) {
         console.log(`Removing gone user ${userKey} from room ${roomId}`);
-        await db.kick(roomId, userKey);
+        await db.kickUser(roomId, userKey);
       }
     }
 
@@ -154,31 +154,8 @@ export function createMainWebSocketFunction(
               console.log(
                 `(${event.requestContext.connectionId}) Leaving room ${roomId}`,
               );
-              const result = await db.deleteUser(roomId, userKey);
-              if (result === undefined) {
-                await publisher.sendError(
-                  event.requestContext.connectionId,
-                  403,
-                  `Invalid userKey ${userKey} for room ${roomId}`,
-                );
-              } else {
-                try {
-                  await publisher.sendMessage(
-                    event.requestContext.connectionId,
-                    {
-                      status: 200,
-                      data: { type: "DELETE_USER", result: "SUCCESS" },
-                    },
-                  );
-                } catch (err) {
-                  console.log(
-                    `Failed to confirm user delete for${userKey}. ${JSON.stringify(
-                      err,
-                    )}. Ignoring.`,
-                  );
-                }
-                await publishRoomData(roomId);
-              }
+              await db.kickUser(roomId, userKey);
+              await publishRoomData(roomId);
               break;
             }
             default: {

--- a/infra/lib/lambda/websockets/WebSocketHelper.ts
+++ b/infra/lib/lambda/websockets/WebSocketHelper.ts
@@ -1,6 +1,15 @@
 import { APIGatewayProxyWebsocketEventV2 } from "aws-lambda";
 import ApiGatewayManagementApi = require("aws-sdk/clients/apigatewaymanagementapi");
 import { RoomData } from "../DbService";
+import { ConnectionGoneError } from "./ConnectionGoneError";
+
+export class PublishRoomDataResult {
+  goneUserKeys;
+
+  constructor(goneUserKeys: string[]) {
+    this.goneUserKeys = goneUserKeys;
+  }
+}
 
 export class WebSocketPublisher {
   endpoint;
@@ -17,11 +26,14 @@ export class WebSocketPublisher {
     });
   }
 
-  async publishRoomData(roomData: RoomData | null) {
+  async publishRoomData(
+    roomData: RoomData | null,
+  ): Promise<PublishRoomDataResult> {
     if (roomData == null) {
-      return;
+      return new PublishRoomDataResult([]);
     }
     console.log(JSON.stringify(roomData));
+    const goneUserKeys: string[] = [];
     for (const recipient of roomData.users) {
       if (recipient.connectionId !== undefined) {
         // parse/stringify to make a deep copy
@@ -39,12 +51,24 @@ export class WebSocketPublisher {
             }
           }
         }
-        await this.sendMessage(recipient.connectionId, {
-          status: 200,
-          data: recipientData,
-        });
+        try {
+          await this.sendMessage(recipient.connectionId, {
+            status: 200,
+            data: recipientData,
+          });
+        } catch (err) {
+          if (
+            err instanceof ConnectionGoneError &&
+            recipient.userKey !== undefined
+          ) {
+            goneUserKeys.push(recipient.userKey);
+          } else {
+            console.log(`Failed to send room data to ${recipient.userKey}`);
+          }
+        }
       }
     }
+    return new PublishRoomDataResult(goneUserKeys);
   }
 
   async sendMessage(connectionId: string, message: object) {
@@ -67,6 +91,16 @@ export class WebSocketPublisher {
         .promise();
     } catch (err) {
       console.log(JSON.stringify(err));
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "statusCode" in err &&
+        err.statusCode == 410
+      ) {
+        throw new ConnectionGoneError(connectionId);
+      } else {
+        throw err;
+      }
     }
   }
 }

--- a/infra/lib/lambda/websockets/WebSocketHelper.ts
+++ b/infra/lib/lambda/websockets/WebSocketHelper.ts
@@ -76,11 +76,11 @@ export class WebSocketPublisher {
       endpoint: this.endpoint,
     });
     console.log(
-      JSON.stringify({
+      `Sending message: ${JSON.stringify({
         endpoint: this.endpoint,
         connectionId,
         message,
-      }),
+      })}`,
     );
     try {
       await api
@@ -97,6 +97,7 @@ export class WebSocketPublisher {
         "statusCode" in err &&
         err.statusCode == 410
       ) {
+        console.log(`Failed to send message: ${connectionId} is gone.`);
         throw new ConnectionGoneError(connectionId);
       } else {
         throw err;

--- a/infra/package.json
+++ b/infra/package.json
@@ -2,8 +2,8 @@
   "name": "guesstimator-infra",
   "scripts": {
     "check-all": "npm run lint &&  npm run test",
-    "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
-    "lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
+    "format": "prettier --ignore-path .gitignore --write .",
+    "lint": "prettier --ignore-path .gitignore --check . && eslint --ignore-path .gitignore .",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage"

--- a/infra/tests/lib/lambda/websockets/Main.test.ts
+++ b/infra/tests/lib/lambda/websockets/Main.test.ts
@@ -23,7 +23,7 @@ describe("WebSocket Main function", () => {
     DbService.prototype.join = vi.fn();
     DbService.prototype.vote = vi.fn();
     DbService.prototype.setCardsRevealed = vi.fn();
-    DbService.prototype.deleteUser = vi.fn();
+    DbService.prototype.kickUser = vi.fn();
     return { DbService };
   });
   vi.mock("../../../../lib/lambda/websockets/WebSocketHelper", () => {
@@ -399,30 +399,7 @@ describe("WebSocket Main function", () => {
     });
   });
   describe("leave", () => {
-    it("Rejects invalid userKey", async () => {
-      // Given
-      const roomId = "roomId";
-      const userKey = "WRONG";
-      const event: APIGatewayProxyWebsocketEventV2 = stubWebSocketEvent({
-        requestContext: {
-          routeKey: "$default",
-          eventType: "MESSAGE",
-        },
-        body: JSON.stringify({
-          action: "leave",
-          data: { roomId, userKey },
-        }),
-      });
-      mockDbService.getRoomMetadata.mockResolvedValue({ roomId });
-      mockDbService.deleteUser.mockResolvedValue(undefined);
-
-      // When
-      await main(event);
-
-      // Then
-      expect(mockWebSocketPublisher.sendError.mock.calls[0][1]).toBe(403);
-    });
-    it("Deletes the user", async () => {
+    it("Kicks the user", async () => {
       // Given
       const roomId = "roomId";
       const userKey = "userKey";
@@ -442,7 +419,7 @@ describe("WebSocket Main function", () => {
       await main(event);
 
       // Then
-      expect(mockDbService.deleteUser).toHaveBeenCalled();
+      expect(mockDbService.kickUser).toHaveBeenCalled();
     });
   });
 });

--- a/infra/tests/lib/lambda/websockets/Main.test.ts
+++ b/infra/tests/lib/lambda/websockets/Main.test.ts
@@ -30,6 +30,7 @@ describe("WebSocket Main function", () => {
     const WebSocketPublisher = vi.fn();
     WebSocketPublisher.prototype.sendError = vi.fn();
     WebSocketPublisher.prototype.publishRoomData = vi.fn();
+    WebSocketPublisher.prototype.sendMessage = vi.fn();
     return { WebSocketPublisher };
   });
 
@@ -161,6 +162,31 @@ describe("WebSocket Main function", () => {
 
     // Then
     expect(mockWebSocketPublisher.sendError.mock.calls[0][1]).toBe(400);
+  });
+
+  describe("ping", () => {
+    it("Responds with 'pong'", async () => {
+      // Given
+      const event: APIGatewayProxyWebsocketEventV2 = stubWebSocketEvent({
+        requestContext: {
+          routeKey: "$default",
+          eventType: "MESSAGE",
+        },
+        body: JSON.stringify({
+          action: "ping",
+          data: {},
+        }),
+      });
+
+      // When
+      const response = await main(event);
+
+      // Then
+      console.log(response);
+      expect(
+        mockWebSocketPublisher.sendMessage.mock.calls[0][1].data.type,
+      ).toEqual("PONG");
+    });
   });
 
   describe("subscribe", () => {

--- a/infra/tests/lib/lambda/websockets/Main.test.ts
+++ b/infra/tests/lib/lambda/websockets/Main.test.ts
@@ -178,6 +178,9 @@ describe("WebSocket Main function", () => {
         }),
       });
       mockDbService.getRoomMetadata.mockResolvedValue({ roomId });
+      mockWebSocketPublisher.publishRoomData.mockResolvedValue({
+        goneUserKeys: [],
+      });
 
       // When
       await main(event);


### PR DESCRIPTION
## Context

There is a problem when a group reuses a room, but someone from a prior session is not there. Somewhat related is a problem where an idle user will lose their connection and the page just stops working. This PR does the following to address both issues:

- Whenever room data is published to clients, any client that is "Gone" (410 status code) gets kicked.
- If a user does get kicked for inactivity, they automatically rejoin when the tab is active or they return to the page.
- Whenever the page tab is active, clients will "ping" the server every 5 minutes to keep the connection from closing.

Some updates that came along for the ride because they were related to the code I was updating:

- When a user leaves the room, the server uses the 'kickUser' operation instead of 'deleteUser'. That simply removes the user's username. It means the client doesn't have to reload the page and the operation appears much more smoothly.
- Users can now leave the room even if the cards are revealed.
- The new user form is replaced by a spinner after the user submits until they get confirmation of joining from the server.

Closes #240
Closes #351 

## Submitter checklist

- [x] All styles are applied with Windi CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

