### PR TITLE
Fix GoneException handling for AWS SDK v3

### DIFF
--- a/infra/lib/lambda/websockets/WebSocketHelper.ts
+++ b/infra/lib/lambda/websockets/WebSocketHelper.ts
@@ -1,7 +1,10 @@
 import { APIGatewayProxyWebsocketEventV2 } from "aws-lambda";
 import { RoomData } from "../DbService";
 import { ConnectionGoneError } from "./ConnectionGoneError";
-import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
+import {
+  ApiGatewayManagementApi,
+  GoneException,
+} from "@aws-sdk/client-apigatewaymanagementapi";
 
 export interface PongWebSocketData {
   type: "PONG";
@@ -114,12 +117,7 @@ export class WebSocketPublisher {
       });
     } catch (err) {
       console.log(JSON.stringify(err));
-      if (
-        typeof err === "object" &&
-        err !== null &&
-        "statusCode" in err &&
-        err.statusCode == 410
-      ) {
+      if (err instanceof GoneException) {
         console.log(`Failed to send message: ${connectionId} is gone.`);
         throw new ConnectionGoneError(connectionId);
       } else {

--- a/infra/tests/lib/lambda/websockets/WebSocketHelper.test.ts
+++ b/infra/tests/lib/lambda/websockets/WebSocketHelper.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, it, vi, expect } from "vitest";
+import { stubWebSocketEvent } from "../Stubs";
+import {
+  WebSocketMessage,
+  WebSocketPublisher,
+} from "../../../../lib/lambda/websockets/WebSocketHelper";
+import {
+  ApiGatewayManagementApi,
+  GoneException,
+} from "@aws-sdk/client-apigatewaymanagementapi";
+
+describe("WebSocket Main function", () => {
+  vi.mock("@aws-sdk/client-apigatewaymanagementapi", async () => {
+    const actual = await vi.importActual(
+      "@aws-sdk/client-apigatewaymanagementapi",
+    );
+    const ApiGatewayManagementApi = vi.fn();
+    ApiGatewayManagementApi.prototype.postToConnection = vi.fn();
+    return {
+      ...actual,
+      ApiGatewayManagementApi,
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("WebSocketPublisher", () => {
+    describe("sendMessage", () => {
+      it("Handles GoneException", async () => {
+        // Given
+        const event = stubWebSocketEvent({});
+        const helper = new WebSocketPublisher(event);
+        const connectionId = "connectionId";
+        const webSocketMessage: WebSocketMessage = {
+          status: 200,
+        };
+        vi.mocked(
+          ApiGatewayManagementApi.prototype.postToConnection,
+        ).mockRejectedValue(
+          new GoneException({
+            $metadata: {
+              httpStatusCode: 410,
+              requestId: "xxx-xxx-xxx-xxx-xxx",
+              attempts: 1,
+              totalRetryDelay: 0,
+            },
+            message: "UnknownError",
+          }),
+        );
+
+        // Then
+        expect(() =>
+          helper.sendMessage(connectionId, webSocketMessage),
+        ).rejects.toThrow(connectionId);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Context

Users should be kicked if they are "gone". The AWS SDK changed the structure of GoneException, so our type checking didn't work. This solution is both more simple and more robust.

## Submitter checklist

- [x] All styles are applied with Tailwind CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

