### PR TITLE
Fix card display

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -50,7 +50,7 @@
       bg-teal-50 rounded-lg border-4 border-teal-600 text-teal-700
       "
     >
-      <div class="text-3xl sm:text-6xl">{displayValue}</div>
+      <div class="text-5xl sm:text-6xl">{displayValue}</div>
       <div class="overflow-hidden break-words [word-break:break-word]">
         {username}
       </div>

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -36,6 +36,7 @@
   $: displayValue = value === "" ? "?" : value;
 </script>
 
+<!-- Playing cards are 2.5 x 3.5 inches, or 1.4x taller than wide -->
 <div class="animate-fade-up">
   {#if isRevealed}
     <div
@@ -43,7 +44,7 @@
       animate-rotate-y {animationDelayClassName}
       shadow-dark-100 shadow-lg
       flex flex-col items-center justify-center
-      w-18 h-28 sm:w-36 sm:h-56
+      w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
       overflow-hidden break-all
       font-bold
@@ -59,7 +60,7 @@
       animate-animated animate-infinite animate-pulse
       shadow-dark-100 shadow-lg
       flex flex-col items-center justify-center
-      w-18 h-28 sm:w-36 sm:h-56
+      w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
       overflow-hidden break-all
       font-bold
@@ -75,7 +76,7 @@
       class="
       shadow-dark-100 shadow-lg
       flex flex-col items-center justify-center
-      w-18 h-28 sm:w-36 sm:h-56
+      w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
       overflow-hidden break-all
       font-bold

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -46,13 +46,14 @@
       flex flex-col items-center justify-center
       w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
-      overflow-hidden break-all
       font-bold
       bg-teal-50 rounded-lg border-4 border-teal-600 text-teal-700
       "
     >
       <div class="text-3xl sm:text-6xl">{displayValue}</div>
-      <div>{username}</div>
+      <div class="overflow-hidden break-words [word-break:break-word]">
+        {username}
+      </div>
     </div>
   {:else if hasValue}
     <div
@@ -62,14 +63,15 @@
       flex flex-col items-center justify-center
       w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
-      overflow-hidden break-all
       font-bold
       bg-teal-700 text-teal-50
       rounded-lg border-4 border-teal-900
       "
     >
       <div class="text-3xl sm:text-6xl text-teal-200">!</div>
-      <div>{username}</div>
+      <div class="overflow-hidden break-words [word-break:break-word]">
+        {username}
+      </div>
     </div>
   {:else}
     <div
@@ -78,14 +80,15 @@
       flex flex-col items-center justify-center
       w-28 h-40 sm:w-36 sm:h-52
       p-2 m-2
-      overflow-hidden break-all
       font-bold
       bg-teal-700 text-teal-50
       rounded-lg border-4 border-teal-900
       "
     >
       <div class="text-3xl sm:text-6xl text-teal-200">&nbsp;</div>
-      <div>{username}</div>
+      <div class="overflow-hidden break-words [word-break:break-word]">
+        {username}
+      </div>
     </div>
   {/if}
 </div>

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -58,7 +58,6 @@
   {:else if hasValue}
     <div
       class="
-      animate-animated animate-infinite animate-pulse
       shadow-dark-100 shadow-lg
       flex flex-col items-center justify-center
       w-28 h-40 sm:w-36 sm:h-52

--- a/frontend/src/routes/rooms/[roomId]/+page.svelte
+++ b/frontend/src/routes/rooms/[roomId]/+page.svelte
@@ -278,7 +278,7 @@
       <ResultsChart {roomData} />
     </section>
   {/if}
-  <section id="userControls" class="mt-32">
+  <section id="userControls" class="sm:mt-32">
     {#if isJoined}
       <TgParagraph
         >If you'd like to vote, enter a name and join the room:</TgParagraph

--- a/frontend/src/routes/rooms/[roomId]/HostControls.svelte
+++ b/frontend/src/routes/rooms/[roomId]/HostControls.svelte
@@ -13,9 +13,9 @@
     isPending = false;
   }
 
-  $: isEveryoneReady = roomData.users
-    .filter((user) => user.username.length > 0)
-    .every((user) => user.hasVote);
+  $: joinedUsers = roomData.users.filter((user) => user.username.length > 0);
+
+  $: isEveryoneReady = joinedUsers.every((user) => user.hasVote);
 
   const dispatch = createEventDispatcher();
 
@@ -37,6 +37,8 @@
     <TgButton id="hideCardsButton" type="secondary" on:click={handleReset}
       >Reset</TgButton
     >
+  {:else if joinedUsers.length === 0}
+    <TgParagraph>Waiting for people to join...</TgParagraph>
   {:else if isEveryoneReady}
     <TgButton id="showCardsButton" type="success" on:click={handleReveal}
       >Reveal cards</TgButton

--- a/frontend/src/routes/rooms/[roomId]/HostControls.svelte
+++ b/frontend/src/routes/rooms/[roomId]/HostControls.svelte
@@ -13,6 +13,10 @@
     isPending = false;
   }
 
+  $: isEveryoneReady = roomData.users
+    .filter((user) => user.username.length > 0)
+    .every((user) => user.hasVote);
+
   const dispatch = createEventDispatcher();
 
   function handleReveal() {
@@ -32,6 +36,10 @@
   {:else if roomData.isRevealed}
     <TgButton id="hideCardsButton" type="secondary" on:click={handleReset}
       >Reset</TgButton
+    >
+  {:else if isEveryoneReady}
+    <TgButton id="showCardsButton" type="success" on:click={handleReveal}
+      >Reveal cards</TgButton
     >
   {:else}
     <TgButton id="showCardsButton" type="secondary" on:click={handleReveal}

--- a/frontend/src/routes/rooms/[roomId]/RoomHeader.svelte
+++ b/frontend/src/routes/rooms/[roomId]/RoomHeader.svelte
@@ -51,31 +51,33 @@
 
 <header class="mt-8">
   Room URL: <span class="whitespace-nowrap">{url}</span>
-  <TgButton
-    id="copyUrlButton"
-    type="secondary"
-    on:click={handleCopyClick}
-    class="relative"
-  >
-    <CopyIcon />
-    {#if copyConfirmationText !== null}
-      <div
-        class="absolute -left-2 -top-4 z-10
+  <span class="whitespace-nowrap">
+    <TgButton
+      id="copyUrlButton"
+      type="secondary"
+      on:click={handleCopyClick}
+      class="relative"
+    >
+      <CopyIcon />
+      {#if copyConfirmationText !== null}
+        <div
+          class="absolute -left-2 -top-4 z-10
         animate-fade-up animate-duration-1000
         bg-slate-100 border-slate-900 border-2 text-slate-900"
-      >
-        {copyConfirmationText}
-      </div>
-    {/if}
-  </TgButton>
-  <TgButton
-    id="qrCodeButton"
-    type="secondary"
-    on:click={handleQrCodeButtonClick}
-    class="relative"
-  >
-    <QrCodeIcon />
-  </TgButton>
+        >
+          {copyConfirmationText}
+        </div>
+      {/if}
+    </TgButton>
+    <TgButton
+      id="qrCodeButton"
+      type="secondary"
+      on:click={handleQrCodeButtonClick}
+      class="relative"
+    >
+      <QrCodeIcon />
+    </TgButton>
+  </span>
   <Modal bind:showModal={showingQrCode}>
     <TgHeadingSub>{url.href}</TgHeadingSub>
     <div class="flex justify-center">

--- a/frontend/tests/e2e/main.test.ts
+++ b/frontend/tests/e2e/main.test.ts
@@ -13,6 +13,10 @@ test("Host workflow", async ({ page }) => {
   expect(await page.title()).toBe("Guesstimator - Home");
   await page.click("#createRoomButton");
 
+  await page.getByRole("textbox").fill("test username");
+  await page.getByText("Join room").click();
+  await page.waitForSelector("#showCardsButton");
+
   await page.click("#showCardsButton");
   await page.click("#hideCardsButton");
 

--- a/frontend/tests/unit/routes/rooms/[roomId]/HostControls.test.ts
+++ b/frontend/tests/unit/routes/rooms/[roomId]/HostControls.test.ts
@@ -4,7 +4,7 @@ import HostControls from "$routes/rooms/[roomId]/HostControls.svelte";
 import userEvent from "@testing-library/user-event";
 import type { Room } from "$lib/services/rooms";
 
-function stubRoom(isRevealed = false, users = [{ username: "" }]): Room {
+function stubRoom(isRevealed = false, users = [{ username: "host" }]): Room {
   return {
     isRevealed,
     users,

--- a/frontend/tests/unit/routes/rooms/[roomId]/HostControls.test.ts
+++ b/frontend/tests/unit/routes/rooms/[roomId]/HostControls.test.ts
@@ -4,9 +4,10 @@ import HostControls from "$routes/rooms/[roomId]/HostControls.svelte";
 import userEvent from "@testing-library/user-event";
 import type { Room } from "$lib/services/rooms";
 
-function stubRoom(isRevealed = false): Room {
+function stubRoom(isRevealed = false, users = [{ username: "" }]): Room {
   return {
     isRevealed,
+    users,
   } as Room;
 }
 describe("HostControls", () => {


### PR DESCRIPTION
## Context

Fixes a few issues with card display:

1. Words didn't wrap correctly. Now they will wrap, including in the middle of a word but only if absolutely necessary.
2. The 'pulse' animation is annoying and gaudy, so this PR removes it.
3. Instead, the "reveal cards" button will turn green if all the votes are in.
4. Cards are also resized a little to match the correct size ratio of playing cards, and to be a bit bigger and fit longer names (especially on mobile).

Closes # <!-- Add the ID of the related issue here -->

## Submitter checklist

- [x] All styles are applied with Tailwind CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

