### PR TITLE
Fix vote overwrite username

### DIFF
--- a/frontend/src/routes/rooms/[roomId]/PendingOperation.ts
+++ b/frontend/src/routes/rooms/[roomId]/PendingOperation.ts
@@ -56,7 +56,6 @@ export class PendingOperation {
 				} with TTL ${this.timeToLive}`,
 			);
 			transformer(user);
-			user.username = this.pendingValue;
 		}
 		this.timeToLive--;
 		if (this.timeToLive <= 0) {

--- a/frontend/tests/e2e/main.test.ts
+++ b/frontend/tests/e2e/main.test.ts
@@ -23,13 +23,14 @@ test('Basic workflow', async ({ page, browser }) => {
 	);
 
 	// Users vote
-	for (const user of users) {
-		const possibleVotes = ['1', '2', '3', '5', '8', '13', '20'];
-		const randomIndex = Math.floor(Math.random() * possibleVotes.length);
-		const vote = possibleVotes[randomIndex];
-		page.waitForTimeout(500);
-		await addVote(user, vote);
-	}
+	const possibleVotes = ['1', '2', '3', '5', '8', '13', '20'];
+	await Promise.all(
+		users.map((user) => {
+			const randomIndex = Math.floor(Math.random() * possibleVotes.length);
+			const vote = possibleVotes[randomIndex];
+			return addVote(user, vote);
+		}),
+	);
 
 	// Host joins and votes
 	console.log('Host is joining');


### PR DESCRIPTION
## Context

The client-side code keeps track of actions (like votes) that the user has performed but have not been echoed back by the server. It applies those changes to every server response locally so to any "outdated" updates it gets until the server finishes making the change (or a TTL expires). That way the user continues to see their change even if a stale update comes in between when they submit and when the next update from the server includes their change.

There was a bug where the client side code would apply the pending value to the username field regardless of what it was for. This would sometimes cause the user's vote to become their username locally. If the user clicked a vote rapidly, it could even end up submitting the 'vote' username as the real username for other users to see.

This PR simply removes the extra assignment to the username field. It was likely leftover from a previous version of the code or a debugging session or something.

I expect this to fix an issue with the E2E tests that made them flaky. They would pass only if each user voted one at a time. The problem was likely because of this error when updates happen very quickly in parallel.

## Submitter checklist

- [x] All styles are applied with Tailwind CSS **OR** this PR does not include style changes
- [x] I have added tests for my change **OR** this PR does not include code changes
- [x] I have updated the documentation as needed
- [x] All PR checks pass

View the latest [QA deploy](https://guesstimator-qa.superfun.link).

